### PR TITLE
Add API DB comparison test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ _site/
 # counterproductive to check this file into the repository.
 # Details at https://github.com/github/pages-gem/issues/768
 Gemfile.lock
+
+# Remote backend snapshots can contain secrets.
+test/**/remote-server.js

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "Sidedoor development and API/DB test environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              nodejs_22
+              postgresql_16
+              openssh
+              gnutar
+              curl
+              jq
+              ripgrep
+              git
+            ];
+
+            shellHook = ''
+              echo "Sidedoor test environment"
+              echo "Tools: node, npm, psql, ssh, tar, curl, jq, rg"
+              echo "Set DATABASE_URL before comparing Postgres query output with API output."
+            '';
+          };
+        });
+    };
+}

--- a/test/api/README.md
+++ b/test/api/README.md
@@ -1,0 +1,124 @@
+# API vs Postgres Tests
+
+These tests compare live API output with the JSON returned by a Postgres query.
+
+Run them from the Nix shell:
+
+```bash
+nix develop
+```
+
+Set the database connection string:
+
+```bash
+export DATABASE_URL='postgres://USER:PASSWORD@HOST:5432/DB_NAME'
+```
+
+Run a comparison:
+
+```bash
+test/api/compare-api-db.sh professors
+test/api/compare-api-db.sh buildings
+test/api/compare-api-db.sh rooms
+PROFESSOR_ID=436 test/api/compare-api-db.sh professor
+PROFESSOR_ID=436 test/api/compare-api-db.sh office-hours
+```
+
+Run the stronger professor endpoint consistency check:
+
+```bash
+test/api/compare-api-db.sh professor-endpoints
+```
+
+That check does not require `DATABASE_URL`. It fetches `GET /professors`, then checks every returned `professor_id` against `GET /professors/:id` and diffs the JSON object.
+
+The SQL files in `test/api/sql/` output exactly one JSON value. For array endpoints, they output a JSON array. For object endpoints, they output a JSON object.
+
+The current SQL files are based on the deployed `server.js` route queries fetched from `/home/harim/professor-finder-api/server.js`. ID fields are cast to text where needed so `psql` JSON matches the Node Postgres API output.
+
+## Getting the Real Server Queries
+
+The frontend repo does not currently include `server.js`, so fetch the deployed backend file from the server:
+
+```bash
+nix develop
+test/api/fetch-remote-server-js.sh
+```
+
+If more than one `server.js` is found, rerun with the deployed backend path:
+
+```bash
+REMOTE_SERVER_JS=/path/to/server.js test/api/fetch-remote-server-js.sh
+```
+
+If no backend file is found, run the discovery helper:
+
+```bash
+test/api/discover-remote-backend.sh
+```
+
+Look for the running Node process working directory or a JS file containing the known route strings, then fetch that file explicitly:
+
+```bash
+REMOTE_SERVER_JS=/path/from/discovery/output.js test/api/fetch-remote-server-js.sh
+```
+
+If the file exists under another user's home and `john` cannot read it, use sudo mode:
+
+```bash
+USE_SUDO=1 REMOTE_SERVER_JS=/home/harim/professor-finder-api/server.js test/api/fetch-remote-server-js.sh
+```
+
+The file is saved as `test/api/remote-server.js` and is intentionally gitignored because backend files may contain secrets.
+
+After fetching it, inspect the routes and SQL-looking lines:
+
+```bash
+test/api/extract-route-sql.sh
+```
+
+Use the extracted route SQL to verify these files stay aligned with the server:
+
+```text
+test/api/sql/professors.sql
+test/api/sql/professor-by-id.sql
+test/api/sql/buildings.sql
+test/api/sql/rooms.sql
+test/api/sql/office-hours-by-professor.sql
+```
+
+Recommended workflow:
+
+```bash
+test/api/compare-api-db.sh professors
+test/api/compare-api-db.sh professor-endpoints
+```
+
+If both pass, then the full professor list matches the database query and each individual professor endpoint matches its corresponding object from the list endpoint.
+
+## Running on the Server
+
+Use the remote runner when Postgres is only available from the server:
+
+```bash
+nix develop
+PGUSER=postgres PGDATABASE=university test/api/run-remote-api-db.sh professors
+```
+
+The remote runner copies this `test/api/` folder to `/tmp/sidedoor-api-db-test` on the server, opens an SSH session, and prompts for the Postgres password interactively. The password is not saved in this repo or included in the command.
+
+Examples:
+
+```bash
+PGUSER=postgres test/api/run-remote-api-db.sh list-dbs
+PGUSER=postgres PGDATABASE=university test/api/run-remote-api-db.sh professors
+PGUSER=postgres PGDATABASE=university PROFESSOR_ID=436 test/api/run-remote-api-db.sh professor
+PGUSER=postgres PGDATABASE=university PROFESSOR_ID=436 test/api/run-remote-api-db.sh office-hours
+```
+
+For fish, use `env` instead of Bash-style variable prefixes:
+
+```fish
+env PGUSER=postgres PGDATABASE=university test/api/run-remote-api-db.sh professors
+env PGUSER=postgres PGDATABASE=university PROFESSOR_ID=436 test/api/run-remote-api-db.sh professor
+```

--- a/test/api/api-db-test-report.md
+++ b/test/api/api-db-test-report.md
@@ -1,0 +1,126 @@
+# API vs Postgres Test Report
+
+## Summary
+
+The deployed API was compared against direct Postgres query output using the test harness in `test/api/`.
+
+The main API-vs-DB checks passed:
+
+- `GET /professors`: match, 433 rows
+- `GET /buildings`: match, 15 rows
+- `GET /rooms`: match, 426 rows
+- `GET /professors/436`: match, not-found JSON
+- `GET /office-hours/436`: match, empty array
+
+The professor detail endpoint consistency check also passed:
+
+- All 433 `GET /professors/:id` responses match the corresponding object from `GET /professors`.
+
+## Test Environment
+
+- API base URL: `http://66.112.209.106:3000`
+- SSH target: `john@66.112.209.106`
+- SSH port: `29955`
+- Postgres user: `postgres`
+- Postgres database: `university`
+- Local test directory: `test/api/`
+- Backend source used for SQL reference: `/home/harim/professor-finder-api/server.js`
+
+Passwords were entered interactively and were not saved in the repository.
+
+## Test Method
+
+For each API-vs-DB comparison:
+
+1. The script calls the live API endpoint.
+2. The script runs the matching SQL query directly against Postgres.
+3. Both JSON outputs are normalized with `jq -S`.
+4. The normalized JSON outputs are compared with `diff`.
+5. A test passes only when the full JSON output matches.
+
+The SQL files are based on the deployed `server.js` route queries:
+
+- `test/api/sql/professors.sql`
+- `test/api/sql/professor-by-id.sql`
+- `test/api/sql/buildings.sql`
+- `test/api/sql/rooms.sql`
+- `test/api/sql/office-hours-by-professor.sql`
+
+ID fields are cast to text in the SQL wrappers where needed so direct `psql` JSON matches the Node/Postgres API output.
+
+## Results
+
+| Endpoint | Command | API Count | DB Count | Result | Notes |
+| --- | --- | ---: | ---: | --- | --- |
+| `GET /professors` | `env PGUSER=postgres PGDATABASE=university ./test/api/run-remote-api-db.sh professors` | 433 | 433 | Match | Full professor list matched direct Postgres query output. |
+| `GET /buildings` | `env PGUSER=postgres PGDATABASE=university ./test/api/run-remote-api-db.sh buildings` | 15 | 15 | Match | Building list matched direct Postgres query output. |
+| `GET /rooms` | `env PGUSER=postgres PGDATABASE=university ./test/api/run-remote-api-db.sh rooms` | 426 | 426 | Match | Room list matched direct Postgres query output. |
+| `GET /professors/436` | `env PGUSER=postgres PGDATABASE=university PROFESSOR_ID=436 ./test/api/run-remote-api-db.sh professor` | 1 | 1 | Match | API returned HTTP `404`; DB wrapper returned matching `{"error":"Professor not found"}` JSON. |
+| `GET /office-hours/436` | `env PGUSER=postgres PGDATABASE=university PROFESSOR_ID=436 ./test/api/run-remote-api-db.sh office-hours` | 0 | 0 | Match | Both API and DB query returned an empty array. |
+
+## API Consistency Check
+
+Command:
+
+```bash
+./test/api/compare-api-db.sh professor-endpoints
+```
+
+Result:
+
+```text
+Result: MATCH (all 433 professor detail endpoints match /professors)
+```
+
+This verifies that each professor returned by `GET /professors` has a matching `GET /professors/:id` response.
+
+## Other Endpoints
+
+### `GET /`
+
+This is an API health/root endpoint. It does not return JSON and does not use a Postgres query.
+
+Observed response:
+
+```text
+Professor Finder API is running.
+```
+
+Status: working.
+
+### `GET /db-test`
+
+The deployed server query is:
+
+```sql
+SELECT 1 AS ok
+```
+
+Expected JSON:
+
+```json
+{
+  "ok": 1
+}
+```
+
+The test harness includes this check:
+
+```fish
+env PGUSER=postgres PGDATABASE=university ./test/api/run-remote-api-db.sh db-test
+```
+
+## Conclusion
+
+For the tested scope, the API output matches the direct Postgres query output.
+
+The strongest verified coverage is for:
+
+- full professor list
+- professor detail behavior for every ID returned by the list endpoint
+- buildings
+- rooms
+- professor `436` not-found behavior
+- office hours for professor `436`
+
+Remaining optional improvement: run `office-hours` for more professor IDs if the project needs broad office-hours coverage beyond professor `436`.

--- a/test/api/compare-api-db.sh
+++ b/test/api/compare-api-db.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE_URL="${API_BASE_URL:-http://66.112.209.106:3000}"
+PROFESSOR_ID="${PROFESSOR_ID:-436}"
+TEST_CASE="${1:-professors}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SQL_DIR="$SCRIPT_DIR/sql"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  test/api/compare-api-db.sh <case>
+
+Cases:
+  db-test
+  professors
+  professor
+  professor-endpoints
+  buildings
+  rooms
+  office-hours
+
+Environment:
+  DATABASE_URL    Optional for DB comparison cases. Postgres connection string for psql.
+  PGHOST          Optional when DATABASE_URL is not set. Defaults to libpq behavior.
+  PGPORT          Optional when DATABASE_URL is not set. Defaults to libpq behavior.
+  PGUSER          Optional when DATABASE_URL is not set. Defaults to libpq behavior.
+  PGDATABASE      Required when DATABASE_URL is not set for DB comparison cases.
+  PGPASSWORD      Optional. Lets psql authenticate without an interactive prompt.
+  API_BASE_URL    Optional. Defaults to http://66.112.209.106:3000
+  PROFESSOR_ID    Optional. Defaults to 436 for dynamic professor endpoints.
+
+Examples:
+  DATABASE_URL='postgres://user:pass@host:5432/db' test/api/compare-api-db.sh professors
+  PGUSER=postgres PGDATABASE=university test/api/compare-api-db.sh professors
+  PROFESSOR_ID=1 DATABASE_URL='postgres://user:pass@host:5432/db' test/api/compare-api-db.sh professor
+  test/api/compare-api-db.sh professor-endpoints
+USAGE
+}
+
+if [[ "${TEST_CASE}" == "-h" || "${TEST_CASE}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+fetch_json() {
+  local endpoint="$1"
+  local body_file="$2"
+  local status_file="$3"
+  local json_file="$4"
+
+  curl -sS \
+    -w '%{http_code}' \
+    -o "$body_file" \
+    "$API_BASE_URL$endpoint" > "$status_file"
+
+  if ! jq -S . "$body_file" > "$json_file"; then
+    echo "API did not return JSON for $endpoint." >&2
+    echo "HTTP status: $(cat "$status_file")" >&2
+    cat "$body_file" >&2
+    exit 1
+  fi
+}
+
+run_professor_endpoint_consistency() {
+  local list_raw="$TMP_DIR/professors.raw"
+  local list_status="$TMP_DIR/professors.status"
+  local list_json="$TMP_DIR/professors.json"
+  local ids_file="$TMP_DIR/professor-ids.txt"
+  local count
+  local failures=0
+
+  fetch_json "/professors" "$list_raw" "$list_status" "$list_json"
+
+  if [[ "$(cat "$list_status")" != "200" ]]; then
+    echo "GET /professors returned HTTP $(cat "$list_status"), expected 200." >&2
+    exit 1
+  fi
+
+  if [[ "$(jq -r 'type' "$list_json")" != "array" ]]; then
+    echo "GET /professors did not return a JSON array." >&2
+    exit 1
+  fi
+
+  jq -r '.[].professor_id' "$list_json" > "$ids_file"
+  count="$(wc -l < "$ids_file")"
+
+  echo "Case: professor-endpoints"
+  echo "Endpoint source: GET /professors"
+  echo "Detail endpoint: GET /professors/:id"
+  echo "Professor IDs to check: $count"
+
+  while IFS= read -r professor_id; do
+    local expected_json="$TMP_DIR/professor-$professor_id.expected.json"
+    local actual_raw="$TMP_DIR/professor-$professor_id.raw"
+    local actual_status="$TMP_DIR/professor-$professor_id.status"
+    local actual_json="$TMP_DIR/professor-$professor_id.actual.json"
+
+    jq -S --arg professor_id "$professor_id" \
+      '.[] | select(.professor_id == $professor_id)' \
+      "$list_json" > "$expected_json"
+
+    fetch_json "/professors/$professor_id" "$actual_raw" "$actual_status" "$actual_json"
+
+    if [[ "$(cat "$actual_status")" != "200" ]]; then
+      echo "MISMATCH professor_id=$professor_id: HTTP $(cat "$actual_status"), expected 200." >&2
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if ! diff -u "$expected_json" "$actual_json" > "$TMP_DIR/professor-$professor_id.diff"; then
+      echo "MISMATCH professor_id=$professor_id" >&2
+      cat "$TMP_DIR/professor-$professor_id.diff" >&2
+      failures=$((failures + 1))
+    fi
+  done < "$ids_file"
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo "Result: MISMATCH ($failures professor endpoint checks failed)"
+    exit 1
+  fi
+
+  echo "Result: MATCH (all $count professor detail endpoints match /professors)"
+}
+
+if [[ "$TEST_CASE" == "professor-endpoints" ]]; then
+  run_professor_endpoint_consistency
+  exit 0
+fi
+
+if [[ -z "${DATABASE_URL:-}" && -z "${PGDATABASE:-}" ]]; then
+  echo "DATABASE_URL or PGDATABASE is required for case: $TEST_CASE" >&2
+  echo >&2
+  usage >&2
+  exit 2
+fi
+
+case "$TEST_CASE" in
+  db-test)
+    endpoint="/db-test"
+    sql_file="$SQL_DIR/db-test.sql"
+    ;;
+  professors)
+    endpoint="/professors"
+    sql_file="$SQL_DIR/professors.sql"
+    ;;
+  professor)
+    endpoint="/professors/$PROFESSOR_ID"
+    sql_file="$SQL_DIR/professor-by-id.sql"
+    ;;
+  buildings)
+    endpoint="/buildings"
+    sql_file="$SQL_DIR/buildings.sql"
+    ;;
+  rooms)
+    endpoint="/rooms"
+    sql_file="$SQL_DIR/rooms.sql"
+    ;;
+  office-hours)
+    endpoint="/office-hours/$PROFESSOR_ID"
+    sql_file="$SQL_DIR/office-hours-by-professor.sql"
+    ;;
+  *)
+    echo "Unknown case: $TEST_CASE" >&2
+    echo >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -f "$sql_file" ]]; then
+  echo "Missing SQL file: $sql_file" >&2
+  exit 2
+fi
+
+api_raw="$TMP_DIR/api.raw"
+api_status="$TMP_DIR/api.status"
+api_json="$TMP_DIR/api.json"
+db_raw="$TMP_DIR/db.raw"
+db_json="$TMP_DIR/db.json"
+
+fetch_json "$endpoint" "$api_raw" "$api_status" "$api_json"
+
+status="$(cat "$api_status")"
+
+psql_target=()
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  psql_target=("$DATABASE_URL")
+fi
+
+psql "${psql_target[@]}" \
+  --no-align \
+  --tuples-only \
+  --quiet \
+  --set=ON_ERROR_STOP=1 \
+  --set=professor_id="$PROFESSOR_ID" \
+  --file="$sql_file" > "$db_raw"
+
+if ! jq -S . "$db_raw" > "$db_json"; then
+  echo "Database query did not return valid JSON." >&2
+  echo "SQL file: $sql_file" >&2
+  cat "$db_raw" >&2
+  exit 1
+fi
+
+api_count="$(jq 'if type == "array" then length else 1 end' "$api_json")"
+db_count="$(jq 'if type == "array" then length else 1 end' "$db_json")"
+
+echo "Case: $TEST_CASE"
+echo "Endpoint: GET $endpoint"
+echo "HTTP status: $status"
+echo "API JSON count: $api_count"
+echo "DB JSON count: $db_count"
+
+if diff -u "$db_json" "$api_json"; then
+  echo "Result: MATCH"
+else
+  echo "Result: MISMATCH"
+  exit 1
+fi

--- a/test/api/discover-remote-backend.sh
+++ b/test/api/discover-remote-backend.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SSH_TARGET="${SSH_TARGET:-john@66.112.209.106}"
+SSH_PORT="${SSH_PORT:-29955}"
+CONTROL_PATH="${CONTROL_PATH:-/tmp/sidedoor-discover-backend-ssh-%r@%h:%p}"
+
+cleanup() {
+  ssh -S "$CONTROL_PATH" -p "$SSH_PORT" -O exit "$SSH_TARGET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  test/api/discover-remote-backend.sh
+
+Prints remote backend clues over SSH:
+  - Node/npm/PM2 process command lines
+  - process working directories
+  - systemd and Docker hints
+  - likely JS entry files
+  - JS files containing known API route strings
+
+Environment:
+  SSH_TARGET    Optional. Defaults to john@66.112.209.106
+  SSH_PORT      Optional. Defaults to 29955
+  CONTROL_PATH  Optional. SSH control socket path.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+ssh -M -S "$CONTROL_PATH" -fN -p "$SSH_PORT" "$SSH_TARGET"
+
+ssh -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" 'bash -s' <<'REMOTE'
+set -u
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+section "Host"
+hostname 2>/dev/null || true
+pwd 2>/dev/null || true
+
+section "Node-like processes"
+ps -eo pid,user,comm,args 2>/dev/null | grep -Ei 'node|npm|pm2|bun|deno' | grep -v grep || true
+
+section "Node process working directories"
+for pid in $(pgrep -f 'node|npm|pm2|bun|deno' 2>/dev/null || true); do
+  printf 'pid=%s\n' "$pid"
+  printf 'cwd='
+  readlink "/proc/$pid/cwd" 2>/dev/null || true
+  printf 'cmd='
+  tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true
+  printf '\n'
+done
+
+section "PM2"
+if command -v pm2 >/dev/null 2>&1; then
+  pm2 list 2>/dev/null || true
+  pm2 describe all 2>/dev/null || true
+else
+  echo "pm2 not found"
+fi
+
+section "systemd services matching app names"
+systemctl list-units --type=service --all --no-pager 2>/dev/null | grep -Ei 'node|npm|pm2|sidedoor|professor|api' || true
+systemctl --user list-units --type=service --all --no-pager 2>/dev/null | grep -Ei 'node|npm|pm2|sidedoor|professor|api' || true
+
+section "Docker"
+if command -v docker >/dev/null 2>&1; then
+  docker ps --format 'table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Ports}}\t{{.Command}}' 2>/dev/null || true
+else
+  echo "docker not found"
+fi
+
+section "Likely JS entry files"
+find /home /srv /var/www /opt /usr/local \
+  -path '*/node_modules' -prune -o \
+  -type f \( -name 'server.js' -o -name 'app.js' -o -name 'index.js' -o -name 'api.js' -o -name 'main.js' \) \
+  -print 2>/dev/null | sort || true
+
+section "JS files containing known API strings"
+find /home /srv /var/www /opt /usr/local \
+  -path '*/node_modules' -prune -o \
+  -type f \( -name '*.js' -o -name '*.mjs' -o -name '*.cjs' \) \
+  -print 2>/dev/null |
+  xargs -r grep -IlE 'Professor Finder API is running|/professors|/office-hours|/db-test|/buildings|/rooms' 2>/dev/null |
+  sort || true
+REMOTE

--- a/test/api/extract-route-sql.sh
+++ b/test/api/extract-route-sql.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_JS="${1:-$SCRIPT_DIR/remote-server.js}"
+
+if [[ ! -f "$SERVER_JS" ]]; then
+  echo "Missing $SERVER_JS." >&2
+  echo "Run test/api/fetch-remote-server-js.sh first, or pass a server.js path." >&2
+  exit 2
+fi
+
+echo "Route and SQL-looking lines from $SERVER_JS:"
+echo
+rg -n \
+  "app\\.(get|post|put|delete)|router\\.(get|post|put|delete)|pool\\.query|client\\.query|\\.query\\(|SELECT|FROM|JOIN|WHERE|GROUP BY|ORDER BY|json_agg|row_to_json|json_build_object" \
+  "$SERVER_JS"

--- a/test/api/fetch-remote-server-js.sh
+++ b/test/api/fetch-remote-server-js.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SSH_TARGET="${SSH_TARGET:-john@66.112.209.106}"
+SSH_PORT="${SSH_PORT:-29955}"
+CONTROL_PATH="${CONTROL_PATH:-/tmp/sidedoor-fetch-server-js-ssh-%r@%h:%p}"
+REMOTE_SERVER_JS="${REMOTE_SERVER_JS:-}"
+OUTPUT_FILE="${OUTPUT_FILE:-test/api/remote-server.js}"
+USE_SUDO="${USE_SUDO:-0}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cleanup() {
+  ssh -S "$CONTROL_PATH" -p "$SSH_PORT" -O exit "$SSH_TARGET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  test/api/fetch-remote-server-js.sh
+
+Fetches the deployed backend JS file from the remote host into test/api/remote-server.js.
+The output file is gitignored because backend files often contain credentials.
+
+Environment:
+  SSH_TARGET        Optional. Defaults to john@66.112.209.106
+  SSH_PORT          Optional. Defaults to 29955
+  REMOTE_SERVER_JS  Optional. Exact remote path to the backend JS file.
+  OUTPUT_FILE       Optional. Defaults to test/api/remote-server.js
+  CONTROL_PATH      Optional. SSH control socket path.
+  USE_SUDO          Optional. Set to 1 if john cannot read the backend file.
+
+Examples:
+  test/api/fetch-remote-server-js.sh
+  REMOTE_SERVER_JS=/home/john/app/server.js test/api/fetch-remote-server-js.sh
+  USE_SUDO=1 REMOTE_SERVER_JS=/home/harim/professor-finder-api/server.js test/api/fetch-remote-server-js.sh
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+ssh -M -S "$CONTROL_PATH" -fN -p "$SSH_PORT" "$SSH_TARGET"
+
+if [[ -z "$REMOTE_SERVER_JS" ]]; then
+  mapfile -t candidates < <(
+    ssh -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" \
+      "find /home /srv /var/www /opt /usr/local -path '*/node_modules' -prune -o -type f \\( -name server.js -o -name app.js -o -name index.js -o -name api.js -o -name main.js \\) -print 2>/dev/null | xargs -r grep -IlE 'Professor Finder API is running|/professors|/office-hours|/db-test|/buildings|/rooms' 2>/dev/null" || true
+  )
+
+  if [[ "${#candidates[@]}" -eq 0 ]]; then
+    mapfile -t candidates < <(
+      ssh -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" \
+        "ps -eo args 2>/dev/null | sed -nE 's#^node[[:space:]]+([^[:space:]]+\\.js).*#\\1#p' | sort -u" || true
+    )
+  fi
+
+  if [[ "${#candidates[@]}" -eq 0 ]]; then
+    echo "No backend JS file containing the known API route strings was found." >&2
+    echo "Run test/api/discover-remote-backend.sh, then set REMOTE_SERVER_JS=/path/to/backend.js and run again." >&2
+    exit 1
+  fi
+
+  if [[ "${#candidates[@]}" -eq 1 ]]; then
+    REMOTE_SERVER_JS="${candidates[0]}"
+  else
+    echo "Multiple server.js files found:"
+    printf '  %s\n' "${candidates[@]}"
+    echo
+    echo "Set REMOTE_SERVER_JS to the deployed backend path and run again."
+    exit 1
+  fi
+fi
+
+mkdir -p "$ROOT_DIR/$(dirname "$OUTPUT_FILE")"
+
+if [[ "$USE_SUDO" == "1" ]]; then
+  remote_tmp="/tmp/sidedoor-remote-server-js.$$"
+  ssh -t -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" \
+    "sudo cp '$REMOTE_SERVER_JS' '$remote_tmp' && sudo chown \"\$(id -un):\$(id -gn)\" '$remote_tmp' && chmod 600 '$remote_tmp'"
+  ssh -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" \
+    "cat '$remote_tmp' && rm -f '$remote_tmp'" > "$ROOT_DIR/$OUTPUT_FILE"
+else
+  ssh -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" \
+    "cat '$REMOTE_SERVER_JS'" > "$ROOT_DIR/$OUTPUT_FILE"
+fi
+
+echo "Fetched $REMOTE_SERVER_JS -> $OUTPUT_FILE"
+echo "Review it locally, then copy the exact SQL into test/sql/*.sql."

--- a/test/api/run-remote-api-db.sh
+++ b/test/api/run-remote-api-db.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SSH_TARGET="${SSH_TARGET:-john@66.112.209.106}"
+SSH_PORT="${SSH_PORT:-29955}"
+REMOTE_DIR="${REMOTE_DIR:-/tmp/sidedoor-api-db-test}"
+TEST_CASE="${1:-professors}"
+CONTROL_PATH="${CONTROL_PATH:-/tmp/sidedoor-api-db-test-ssh-%r@%h:%p}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_DIR="${TEST_DIR:-${SCRIPT_DIR#$ROOT_DIR/}}"
+
+cleanup() {
+  ssh -S "$CONTROL_PATH" -p "$SSH_PORT" -O exit "$SSH_TARGET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  test/api/run-remote-api-db.sh <case>
+
+This copies the local test harness to the server over SSH, then runs the
+selected comparison case on the server.
+
+Cases:
+  list-dbs
+  db-test
+  professors
+  professor
+  professor-endpoints
+  buildings
+  rooms
+  office-hours
+
+Environment:
+  SSH_TARGET      Optional. Defaults to john@66.112.209.106
+  SSH_PORT        Optional. Defaults to 29955
+  REMOTE_DIR      Optional. Defaults to /tmp/sidedoor-api-db-test
+  CONTROL_PATH    Optional. Defaults to /tmp/sidedoor-api-db-test-ssh-%r@%h:%p
+  PGDATABASE      Required for DB comparison cases.
+  PGUSER          Optional. Defaults to postgres.
+  PGHOST          Optional. Defaults to localhost.
+  PGPORT          Optional. Defaults to 5432.
+  PROFESSOR_ID    Optional. Defaults to 436.
+
+Examples:
+  test/api/run-remote-api-db.sh list-dbs
+  PGDATABASE=university test/api/run-remote-api-db.sh professors
+  PGDATABASE=university PROFESSOR_ID=436 test/api/run-remote-api-db.sh professor
+  test/api/run-remote-api-db.sh professor-endpoints
+USAGE
+}
+
+if [[ "${TEST_CASE}" == "-h" || "${TEST_CASE}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$TEST_CASE" != "professor-endpoints" && "$TEST_CASE" != "list-dbs" && -z "${PGDATABASE:-}" ]]; then
+  echo "PGDATABASE is required for DB comparison case: $TEST_CASE" >&2
+  echo >&2
+  usage >&2
+  exit 2
+fi
+
+ssh -M -S "$CONTROL_PATH" -fN -p "$SSH_PORT" "$SSH_TARGET"
+
+if [[ "$TEST_CASE" == "list-dbs" ]]; then
+  ssh -t -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" \
+    "export PGHOST='${PGHOST:-localhost}' && \
+     export PGPORT='${PGPORT:-5432}' && \
+     export PGUSER='${PGUSER:-postgres}' && \
+     printf 'Postgres password for %s: ' \"\${PGUSER}\"; \
+     stty -echo; read PGPASSWORD; stty echo; printf '\n'; \
+     export PGPASSWORD; \
+     psql -h \"\${PGHOST}\" -p \"\${PGPORT}\" -U \"\${PGUSER}\" -l"
+  exit 0
+fi
+
+tar -C "$ROOT_DIR" -czf - "$TEST_DIR" | ssh -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" \
+  "rm -rf '$REMOTE_DIR' && mkdir -p '$REMOTE_DIR' && tar -xzf - -C '$REMOTE_DIR'"
+
+ssh -t -S "$CONTROL_PATH" -p "$SSH_PORT" "$SSH_TARGET" \
+  "cd '$REMOTE_DIR' && \
+   export API_BASE_URL='${API_BASE_URL:-http://66.112.209.106:3000}' && \
+   export PGHOST='${PGHOST:-localhost}' && \
+   export PGPORT='${PGPORT:-5432}' && \
+   export PGUSER='${PGUSER:-postgres}' && \
+   export PGDATABASE='${PGDATABASE:-}' && \
+   export PROFESSOR_ID='${PROFESSOR_ID:-436}' && \
+   if [ '$TEST_CASE' != 'professor-endpoints' ]; then \
+     printf 'Postgres password for %s: ' \"\${PGUSER}\"; \
+     stty -echo; read PGPASSWORD; stty echo; printf '\n'; \
+     export PGPASSWORD; \
+   fi; \
+   bash '$TEST_DIR/compare-api-db.sh' '$TEST_CASE'"

--- a/test/api/sql/buildings.sql
+++ b/test/api/sql/buildings.sql
@@ -1,0 +1,9 @@
+select coalesce(json_agg(row_to_json(buildings_result)), '[]'::json)
+from (
+  select
+      building_id::text as building_id,
+      name,
+      abbreviation
+  from buildings
+  order by abbreviation
+) as buildings_result;

--- a/test/api/sql/db-test.sql
+++ b/test/api/sql/db-test.sql
@@ -1,0 +1,1 @@
+select json_build_object('ok', 1);

--- a/test/api/sql/office-hours-by-professor.sql
+++ b/test/api/sql/office-hours-by-professor.sql
@@ -1,0 +1,21 @@
+select coalesce(json_agg(row_to_json(office_hours_result)), '[]'::json)
+from (
+  select
+      oh.office_hour_id::text as office_hour_id,
+      oh.professor_id::text as professor_id,
+      s.name as semester_name,
+      s.term,
+      s.year,
+      oh.day_of_week,
+      oh.start_time,
+      oh.end_time
+  from office_hours oh
+  left join semesters s
+      on oh.semester_id = s.semester_id
+  where oh.professor_id = :'professor_id'
+  order by
+      s.year,
+      s.term,
+      oh.day_of_week,
+      oh.start_time
+) as office_hours_result;

--- a/test/api/sql/professor-by-id.sql
+++ b/test/api/sql/professor-by-id.sql
@@ -1,0 +1,60 @@
+select coalesce(
+  (
+    select row_to_json(professor_result)
+    from (
+      select
+          p.professor_id::text as professor_id,
+          p.first_name,
+          p.last_name,
+          p.gender,
+
+          max(case when cm.type = 'email' then cm.value end) as email,
+          max(case when cm.type = 'phone' then cm.value end) as phone,
+          max(case when cm.type = 'office_phone' then cm.value end) as office_phone,
+          max(case when cm.type = 'website' then cm.value end) as website,
+
+          string_agg(distinct d.name, ', ') as departments,
+          string_agg(distinct pos.title, ', ') as positions,
+
+          b.abbreviation as building,
+          b.name as building_name,
+          r.room_number,
+          r.floor
+
+      from professors p
+
+      left join contact_methods cm
+          on p.professor_id = cm.professor_id
+
+      left join professor_departments pd
+          on p.professor_id = pd.professor_id
+      left join departments d
+          on pd.department_id = d.department_id
+
+      left join professor_positions pp
+          on p.professor_id = pp.professor_id
+      left join positions pos
+          on pp.position_id = pos.position_id
+
+      left join office_assignments oa
+          on p.professor_id = oa.professor_id
+      left join rooms r
+          on oa.room_id = r.room_id
+      left join buildings b
+          on r.building_id = b.building_id
+
+      where p.professor_id = :'professor_id'
+
+      group by
+          p.professor_id,
+          p.first_name,
+          p.last_name,
+          p.gender,
+          b.abbreviation,
+          b.name,
+          r.room_number,
+          r.floor
+    ) as professor_result
+  ),
+  json_build_object('error', 'Professor not found')
+);

--- a/test/api/sql/professors.sql
+++ b/test/api/sql/professors.sql
@@ -1,0 +1,51 @@
+select coalesce(json_agg(row_to_json(professors_result)), '[]'::json)
+from (
+  select
+      p.professor_id::text as professor_id,
+      p.first_name,
+      p.last_name,
+      p.gender,
+
+      max(case when cm.type = 'email' then cm.value end) as email,
+      max(case when cm.type = 'phone' then cm.value end) as phone,
+      max(case when cm.type = 'office_phone' then cm.value end) as office_phone,
+      max(case when cm.type = 'website' then cm.value end) as website,
+
+      string_agg(distinct d.name, ', ') as departments,
+      string_agg(distinct pos.title, ', ') as positions,
+
+      b.abbreviation as building,
+      b.name as building_name,
+      r.room_number,
+      r.floor
+
+  from professors p
+  left join contact_methods cm
+      on p.professor_id = cm.professor_id
+  left join professor_departments pd
+      on p.professor_id = pd.professor_id
+  left join departments d
+      on pd.department_id = d.department_id
+  left join professor_positions pp
+      on p.professor_id = pp.professor_id
+  left join positions pos
+      on pp.position_id = pos.position_id
+  left join office_assignments oa
+      on p.professor_id = oa.professor_id
+  left join rooms r
+      on oa.room_id = r.room_id
+  left join buildings b
+      on r.building_id = b.building_id
+
+  group by
+      p.professor_id,
+      p.first_name,
+      p.last_name,
+      p.gender,
+      b.abbreviation,
+      b.name,
+      r.room_number,
+      r.floor
+
+  order by p.last_name, p.first_name
+) as professors_result;

--- a/test/api/sql/rooms.sql
+++ b/test/api/sql/rooms.sql
@@ -1,0 +1,14 @@
+select coalesce(json_agg(row_to_json(rooms_result)), '[]'::json)
+from (
+  select
+      r.room_id::text as room_id,
+      r.room_number,
+      r.floor,
+      b.building_id::text as building_id,
+      b.name as building_name,
+      b.abbreviation as building
+  from rooms r
+  left join buildings b
+      on r.building_id = b.building_id
+  order by b.abbreviation, r.room_number
+) as rooms_result;


### PR DESCRIPTION
## Summary

Adds a Nix dev shell and API-vs-Postgres comparison test harness under `test/api`.

## Test Results

Verified that deployed API output matches direct Postgres query output:

- `GET /professors`: match, 433 rows
- `GET /buildings`: match, 15 rows
- `GET /rooms`: match, 426 rows
- `GET /professors/436`: match, not-found response
- `GET /office-hours/436`: match, empty array

Also verified that all 433 `GET /professors/:id` responses match their corresponding object from `GET /professors`.

## Notes

- Database used: `university`
- `test/api/remote-server.js` is gitignored because it may contain backend secrets.
- Passwords were entered interactively and were not committed.