### PR TITLE
Use HTTPS API endpoint

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "https://66.112.209.106:3000";

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,17 +1,12 @@
-
+import { API_BASE_URL } from './config.js';
 import { buildProfessorList } from './prof-list.js';
 
+const response = await fetch(`${API_BASE_URL}/professors`);
 
-// ----- Sample API request (temp/one-time) ----- //
-// Send a fetch request to the API
-const response = await fetch("http://66.112.209.106:3000/professors");
-// It returns a huge string, which needs to be parsed as JSON data
+if (!response.ok) {
+    throw new Error(`Failed to fetch professors: ${response.status}`);
+}
+
 const professors = await response.json();
 
-
-// --- Hard-coded mock API response for testing purposes --- //
-// import professors from './mock_api_response.js';
-
-
-// Build out the appropriate DOM elements using the API fetch results
 buildProfessorList(professors);

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -1,3 +1,5 @@
+import { API_BASE_URL } from './config.js';
+
 const [esriConfig, Map, MapView, Graphic, GraphicsLayer] =
     await $arcgis.import([
         "@arcgis/core/config.js",
@@ -6,8 +8,6 @@ const [esriConfig, Map, MapView, Graphic, GraphicsLayer] =
         "@arcgis/core/Graphic.js",
         "@arcgis/core/layers/GraphicsLayer.js",
     ]);
-
-const API_BASE_URL = "http://66.112.209.106:3000";
 
 // 1. Get ArcGIS config from backend
 const mapConfig = await fetch(`${API_BASE_URL}/map/config`)


### PR DESCRIPTION
## Summary

- Added a shared API config file for the frontend
- Updated professor list fetch requests to use the HTTPS API endpoint
- Updated map API requests to use the same shared HTTPS base URL
- Removed the hard-coded HTTP API URL that caused mixed-content errors on GitHub Pages

## Why

GitHub Pages serves the frontend over HTTPS, so browser requests to the old HTTP API endpoint were blocked as mixed active content.

The backend API is now available over HTTPS at:

```text
https://66.112.209.106:3000